### PR TITLE
Adding a new float type that masks exponent or fraction.

### DIFF
--- a/ff-core/src/lib.rs
+++ b/ff-core/src/lib.rs
@@ -1,14 +1,14 @@
 //! Library code for Fractal Farlands.
 
 pub mod mandelbrot;
+pub mod masked_float;
 mod numeric;
 
 /// A pair of integer (x, y) dimensions.
-#[derive(Copy,Clone,Debug,PartialEq,Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Size {
     pub x: usize,
     pub y: usize,
 }
-
 
 pub mod image;

--- a/ff-core/src/mandelbrot.rs
+++ b/ff-core/src/mandelbrot.rs
@@ -14,20 +14,22 @@ pub fn evaluate<N>(
     y_bounds: &Range<BigRational>,
     size: Size,
     iterations: usize,
-) -> Result<Vec<Option<usize>>, String> where N: MandelbrotNumber {
+) -> Result<Vec<Option<usize>>, String>
+where
+    N: MandelbrotNumber,
+{
     let mut eval = MandelbrotEval::<N>::new(x_bounds, y_bounds, size)?;
     // TODO: incremental evaluation; check for cancellation.
     eval.advance(iterations);
     Ok(eval.state())
 }
 
-
 /// Type-erased, state-preserving Mandelbrot evaluator.
-/// 
+///
 /// A Mandelbrot represents a "current state" of the Mandelbrot fractal over a given coordinate window,
 /// at a particular number of iterations.
 /// It can be advanced without losing that state.
-/// 
+///
 /// It returns its state as a vector of escapes: at which iteration each coordinate's value escaped past
 /// the existing bounds.
 pub trait Mandelbrot {
@@ -64,8 +66,6 @@ pub struct MandelbrotEval<N> {
     /// State: coordinate-and-trace pair, at the corresponding number of iterations.
     state: Vec<MandelbrotCell<N>>,
 }
-
-
 
 impl<N> MandelbrotEval<N>
 where

--- a/ff-core/src/mandelbrot/number.rs
+++ b/ff-core/src/mandelbrot/number.rs
@@ -2,6 +2,8 @@ use std::ops::{Add, Div, Mul, Sub};
 
 use num::{BigRational, ToPrimitive};
 
+use crate::masked_float::MaskedFloat;
+
 /// A numeric type that can can be used for the Mandelbrot fractal.
 ///
 /// This trait identifies the necessary operations to compute a Mandelbrot image:
@@ -68,6 +70,18 @@ impl MandelbrotNumber for BigRational {
     }
     fn from_bigrational(value: &BigRational) -> Option<Self> {
         Some(value.to_owned())
+    }
+}
+
+impl<const E: usize, const F: usize> MandelbrotNumber for MaskedFloat<E, F> {
+    fn zero() -> Self {
+        MaskedFloat::<E, F>::new(0.0)
+    }
+    fn four() -> Self {
+        MaskedFloat::<E, F>::new(4.0)
+    }
+    fn from_bigrational(value: &BigRational) -> Option<Self> {
+        Some(MaskedFloat::<E, F>::new(value.to_f64()?))
     }
 }
 

--- a/ff-core/src/masked_float.rs
+++ b/ff-core/src/masked_float.rs
@@ -1,0 +1,163 @@
+// Sizes and masks to select the components of an IEEE f64.
+const EXPONENT: usize = 11;
+const FRACTION: usize = 52;
+const SIGN_MASK: u64 = 1 << 63;
+const EXPONENT_SIGN_MASK: u64 = 1 << 62;
+const EXPONENT_MASK: u64 = ((1 << EXPONENT) - 1) << FRACTION;
+const FRACTION_MASK: u64 = (1 << FRACTION) - 1;
+
+// Generate all necessary exponent and fraction bitmasks at compile-time.
+const EXPONENT_MASKS: [u64; EXPONENT] = {
+    let mut arr = [0u64; EXPONENT];
+    let mut i = 0;
+    while i < EXPONENT {
+        arr[EXPONENT - i - 1] = ((1 << i) - 1) << (62 - i) as u64;
+        i += 1;
+    }
+    arr
+};
+const FRACTION_MASKS: [u64; FRACTION] = {
+    let mut arr = [0u64; FRACTION];
+    let mut i = 0;
+    while i < FRACTION {
+        arr[FRACTION - i - 1] = (!((1 << i) - 1)) & FRACTION_MASK;
+        i += 1;
+    }
+    arr
+};
+
+/// Masked variant of an f64 that limits the available number of usable exponent
+/// and fraction bits. The underlying float type is f64, so the number of
+/// Exponent bits (E) must be 10 or fewer, and the number of fraction bits
+/// must be 52 or fewer.
+/// IEEE float's exponents use an offset-binary approach for the exponent,
+/// i.e, the 11 exponent bits represent an unsigned number that has 1023
+/// subtracted from it, so masking out some bits is not as easy as it is
+/// for the fractional bits:
+///
+/// For exponents less than 1023, the MSB will not be set, and these will end
+/// up as negative numbers.
+///
+/// To limit these to a smaller bitwidth, we want to clamp the values when they would
+/// overflow, i.e., if it were 8-bit, 127 biased,
+///
+///  0b0000_0001 would be the smallest normal exponent, 2^(-126).
+///
+/// If we want to force this into acting like a 6-bit value, we have to set all
+/// values less than 64 to be 64, i.e.,  0b0010_0000, allowing any values larger
+/// than that to stay as they are.
+///
+/// For positive exponents, we have to instead clamp above, i.e.,
+///   0b1010_0101 becomes 0b1010_000
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
+pub struct MaskedFloat<const E: usize, const M: usize> {
+    val: f64,
+}
+
+impl<const E: usize, const F: usize> MaskedFloat<E, F> {
+    pub fn new(val: f64) -> Self {
+        let bits = val.to_bits();
+        let sign = bits & (SIGN_MASK | EXPONENT_SIGN_MASK);
+        let exp = if bits & EXPONENT_SIGN_MASK != 0 {
+            if bits & EXPONENT_MASKS[E] != 0 {
+                ((1 << E + FRACTION) - 1) & EXPONENT_MASK
+            } else {
+                (bits & !EXPONENT_MASKS[E]) & EXPONENT_MASK
+            }
+        } else {
+            // bits & EXPONENT_SIGN_MASK == 0
+            if bits & EXPONENT_MASKS[E] != EXPONENT_MASKS[E] {
+                EXPONENT_MASKS[E]
+            } else {
+                (bits | EXPONENT_MASKS[E]) & EXPONENT_MASK
+            }
+        };
+        let frac = bits & FRACTION_MASKS[F];
+        Self {
+            val: f64::from_bits(sign | exp | frac),
+        }
+    }
+
+    pub fn to_f64(&self) -> f64 {
+        self.val
+    }
+}
+
+impl<const E: usize, const F: usize> std::ops::Add for MaskedFloat<E, F> {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self {
+            val: self.val + other.val,
+        }
+    }
+}
+
+impl<const E: usize, const F: usize> std::ops::Sub for MaskedFloat<E, F> {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        Self {
+            val: self.val - other.val,
+        }
+    }
+}
+
+impl<const E: usize, const F: usize> std::ops::Mul for MaskedFloat<E, F> {
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self {
+        Self {
+            val: self.val * other.val,
+        }
+    }
+}
+
+impl<const E: usize, const F: usize> std::ops::Div for MaskedFloat<E, F> {
+    type Output = Self;
+
+    fn div(self, other: Self) -> Self {
+        Self {
+            val: self.val / other.val,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_one_plus_one() {
+        let one = MaskedFloat::<10, 10>::new(1.0);
+        let two = MaskedFloat::<10, 10>::new(2.0);
+        let epsilon = MaskedFloat::<10, 10>::new(0.001);
+
+        assert!((one + one).to_f64() - 2.0 < 0.001);
+        assert!(one + one - two < epsilon);
+    }
+
+    #[test]
+    fn test_masking_big() {
+        // Shouldn't be able to represent 2^64 with 6 bits of exponent.
+        let f = f64::powf(2.1, 64.0);
+        let too_big = MaskedFloat::<6, 50>::new(f);
+        assert!(too_big.to_f64() < f);
+
+        // Should be able to represent 2^64 with 8 bits of exponent.
+        let ok = MaskedFloat::<8, 50>::new(f);
+        assert!(ok.to_f64() - f < 0.001);
+    }
+
+    #[test]
+    fn test_masking_small() {
+        // Shouldn't be able to represent 2^-64 with 4 bits of exponent.
+        let f = f64::powf(2.1, -64.0);
+        let too_small = MaskedFloat::<6, 50>::new(f);
+        assert!(too_small.to_f64() > f);
+
+        // Should be able to represent 2^-64 with 8 bits of exponent.
+        let ok = MaskedFloat::<8, 50>::new(f);
+        assert!(ok.to_f64() - f < 0.001);
+    }
+}

--- a/ff-web/src/interface.rs
+++ b/ff-web/src/interface.rs
@@ -93,6 +93,8 @@ fn interface_body(query_str: &str, query: &WindowParams) -> Markup {
 
             (render(query_str, &query.fractal, "f32", query.res))
             (render(query_str, &query.fractal, "f64", query.res))
+            (render(query_str, &query.fractal, "MaskedFloat<3,50>", query.res))
+            (render(query_str, &query.fractal, "MaskedFloat<4,50>", query.res))
         }
 
     }

--- a/ff-web/src/render.rs
+++ b/ff-web/src/render.rs
@@ -6,7 +6,7 @@ use axum::{
     },
     response::IntoResponse,
 };
-use ff_core::mandelbrot;
+use ff_core::{mandelbrot, masked_float};
 use num::BigRational;
 use num_bigint::BigInt;
 
@@ -46,6 +46,8 @@ fn mandelbrot_render(
     let computed = match numeric {
         "f32" => mandelbrot::evaluate::<f32>(&x_range, &y_range, size, query.iters),
         "f64" => mandelbrot::evaluate::<f64>(&x_range, &y_range, size, query.iters),
+        "MaskedFloat<3,50>" => mandelbrot::evaluate::<masked_float::MaskedFloat<3,50>>(&x_range, &y_range, size, query.iters),
+        "MaskedFloat<4,50>" => mandelbrot::evaluate::<masked_float::MaskedFloat<4,50>>(&x_range, &y_range, size, query.iters),
         _ => return Err(axum::http::StatusCode::NOT_FOUND.into()),
     };
     tracing::debug!("mandelbrot-computed");


### PR DESCRIPTION
I think I've worked out all off the off-by-one errors I had in this, and it only ends up rendering a little bit (~20%) slower than using native f64. IMO, masking off the exponent bits leads to neater looking distortion than when we hit the limits of fractional bits.