### PR TITLE
Add smooth coloring, fix coloring bug.

### DIFF
--- a/ff-core/src/mandelbrot/number.rs
+++ b/ff-core/src/mandelbrot/number.rs
@@ -34,6 +34,9 @@ pub trait MandelbrotNumber:
     fn four() -> Self {
         Self::two() + Self::two()
     }
+
+    // Provides a way to get a f64 from this type.
+    fn to_f64(self) -> f64;
 }
 
 impl MandelbrotNumber for f32 {
@@ -47,6 +50,10 @@ impl MandelbrotNumber for f32 {
 
     fn four() -> Self {
         4f32
+    }
+
+    fn to_f64(self) -> f64 {
+        self.into()
     }
 }
 
@@ -62,6 +69,10 @@ impl MandelbrotNumber for f64 {
     fn four() -> Self {
         4f64
     }
+
+    fn to_f64(self) -> f64 {
+        self
+    }
 }
 
 impl MandelbrotNumber for BigRational {
@@ -73,6 +84,9 @@ impl MandelbrotNumber for BigRational {
     }
     fn four() -> Self {
         BigRational::new(4.into(), 1.into())
+    }
+    fn to_f64(self) -> f64 {
+        ToPrimitive::to_f64(&self).unwrap()
     }
 }
 
@@ -86,6 +100,10 @@ impl<const E: usize, const F: usize> MandelbrotNumber for MaskedFloat<E, F> {
 
     fn four() -> Self {
         MaskedFloat::<E, F>::new(4.0)
+    }
+
+    fn to_f64(self) -> f64 {
+        self.into()
     }
 }
 
@@ -103,6 +121,10 @@ macro_rules! impl_fixed {
 
             fn four() -> Self {
                 Self::unwrapped_from_num(4)
+            }
+
+            fn to_f64(self) -> f64 {
+                self.into()
             }
         }
 


### PR DESCRIPTION
The old coloring math had a bug, since it was setting 'hprime' to an integer too early, we only were getting 6 possible colors.

Now we have smooth colors. Used the algorithm from: https://mrob.com/pub/muency/continuousdwell.html

New version of the wave from https://github.com/cceckman/fractal-farlands/issues/11#issuecomment-1968282486:

![smooth_wave](https://github.com/cceckman/fractal-farlands/assets/1103795/a0e54a87-dbf2-41cf-8716-0a7bfe4f8c94)

I11F5 looks cool here too:

![I11F5_zoom](https://github.com/cceckman/fractal-farlands/assets/1103795/b8101dd1-e88e-4807-a78a-2ae3ede17bdd)

See issue #8 
