### PR TITLE
Allow requests to be gracefully canceled

### DIFF
--- a/ff-core/src/lib.rs
+++ b/ff-core/src/lib.rs
@@ -12,6 +12,20 @@ mod numeric;
 
 pub use numeric::FromRational;
 
+/// Represents a cancellation token: something that can be used to check whether computation should be canceled.
+pub trait CancelContext : Sync {
+    fn is_canceled(&self) -> bool;
+}
+
+
+// A CancelContext which is never canceled.
+pub struct NeverCancel();
+impl CancelContext for NeverCancel {
+    fn is_canceled(&self) -> bool {
+        false
+    }
+}
+
 /// Rendering-request parameters, common across renderables.
 #[derive(Debug, Clone)]
 pub struct CommonParams {

--- a/ff-core/src/newton.rs
+++ b/ff-core/src/newton.rs
@@ -5,14 +5,14 @@ use std::{ops::Range, panic::AssertUnwindSafe};
 // Implementation of Newton's fractal for z^3-1
 // TODO:
 //   Parameterize to other functions
-use crate::{masked_float::MaskedFloat, numeric::Complex, CommonParams};
+use crate::{masked_float::MaskedFloat, numeric::Complex, CancelContext, CommonParams};
 
 pub use crate::number::FractalNumber;
 use crate::{Zero, ZeroVector};
 use num::BigRational;
 
 /// Function pointer for evaluating zeros
-type EscapeFn = fn(&CommonParams, usize) -> Result<ZeroVector, String>;
+type EscapeFn = fn(&dyn CancelContext, &CommonParams, usize) -> Result<ZeroVector, String>;
 
 const FUNCTIONS: &[(&'static str, EscapeFn)] = &[
     ("f32", evaluate_parallel_numeric::<f32>),
@@ -36,12 +36,12 @@ pub fn formats() -> impl Iterator<Item = &'static str> {
     FUNCTIONS.iter().map(|(name, _)| *name)
 }
 
-pub fn compute(params: &CommonParams, iterations: usize) -> Result<ZeroVector, String> {
+pub fn compute(ctx: &dyn CancelContext, params: &CommonParams, iterations: usize) -> Result<ZeroVector, String> {
     let fmt = params.numeric.as_str();
     // Linear scan, we don't have that many options:
     for (candidate, computer) in FUNCTIONS.iter() {
         if *candidate == fmt {
-            return computer(params, iterations);
+            return computer(ctx, params, iterations);
         }
     }
 
@@ -49,6 +49,7 @@ pub fn compute(params: &CommonParams, iterations: usize) -> Result<ZeroVector, S
 }
 
 fn evaluate_parallel_numeric<N>(
+    ctx: &dyn CancelContext,
     params: &CommonParams,
     iterations: usize,
 ) -> Result<ZeroVector, String>
@@ -79,6 +80,10 @@ where
         .par_bridge()
         .into_par_iter()
         .for_each(|(y, row_out)| {
+            if ctx.is_canceled() {
+                return
+            }
+
             let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
                 xs.iter().zip(row_out).for_each(|(x, out)| {
                     *out = find_zero(x, &y, iterations);
@@ -90,6 +95,10 @@ where
         });
 
     let mut zero_index: Vec<Complex<N>> = Vec::new();
+
+    if ctx.is_canceled() {
+        return Err("canceled".to_string())
+    }
 
     Ok(zeros
         .into_iter()

--- a/ff-render/src/oneshot.rs
+++ b/ff-render/src/oneshot.rs
@@ -30,9 +30,9 @@ pub struct Sender<T> {
     shared: Arc<Sync<T>>,
 }
 
-impl<T> Sender<T> {
+impl<T> ff_core::CancelContext for Sender<T> where T: Send {
     /// Returns true if the receiver has hung up.
-    pub fn is_cancelled(&self) -> bool {
+    fn is_canceled(&self) -> bool {
         let g = match self.shared.state.lock() {
             Err(_) => return true,
             Ok(v) => v,
@@ -43,7 +43,9 @@ impl<T> Sender<T> {
             false
         }
     }
+}
 
+impl<T> Sender<T> {
     /// Sends the provided value.
     pub fn send(self, value: T) {
         let mut g = match self.shared.state.lock() {


### PR DESCRIPTION
The "oneshot" sender has had support for this for a while, but it wasn't
plumbed through.

Prior to this commit, if the tokio runtime dropped a "render in BG
thread" request, it would still be rendered- blocking rendering of a
reloaded page, if one was present.

This makes it so that _if_ the runtime drops the request processing,
we'll cancel some of the other processing relatively promptly (at the
end of the current row.)

(It's not clear to me whether Axum/Tokio/Hyper know to drop the
request...but seems a bit more responsive?)

